### PR TITLE
add instructions to install using venv + pip

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,14 +9,27 @@ This is a simple app to display a live spectrogram from microphone input (includ
 Installation
 ------------
 
+conda
+~~~~~
+
 Assuming you have git cloned the repo and have a command prompt in the cloned directory,
-you can use `conda` to create an environment with all necessary dependencies:
+you can use :code:`conda` to create an environment with all necessary dependencies:
 
 >>> conda env create -f environment.yml
 
 Note: I have developed this on MacOS and found out that using pyaudio (bindings for PortAudio) required additional
 steps such as installing PortAudio using brew. YMMV.
 
+virtualenv + pip
+~~~~~~~~~~~~~~~~
+
+You can also install dependencies for this project in a virtualenv using :code:`pip`:
+
+>>> python3 -m venv venv
+>>> source venv/bin/activate
+>>> python3 -m pip install -r requirements.txt
+
+Note that on Ubuntu you might need to install the following packages beforehand: :code:`apt-get install python3-venv libasound-dev portaudio19-dev libportaudio2 libportaudiocpp0`.
 
 Usage
 -----

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,12 @@
+cycler==0.10.0
+kiwisolver==1.1.0
+matplotlib==3.1.1
+numpy==1.17.2
+pkg-resources==0.0.0
+PyAudio==0.2.11
+pyparsing==2.4.2
+PyQt5==5.13.1
+PyQt5-sip==12.7.0
+pyqtgraph==0.10.0
+python-dateutil==2.8.0
+six==1.12.0


### PR DESCRIPTION
Hey,

I tried to install the project locally on Ubuntu using pip + virtualenv and with minimal changes it's working nicely. I just added a `requirements.txt` file as well as some instructions in the README for additional required dependencies.

Cheers,
Rémi