### PR TITLE
Add missing native dependency to make things work on Ubuntu

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ You can also install dependencies for this project in a virtualenv using :code:`
 >>> source venv/bin/activate
 >>> python3 -m pip install -r requirements.txt
 
-Note that on Ubuntu you might need to install the following packages beforehand: :code:`apt-get install python3-venv libasound-dev portaudio19-dev libportaudio2 libportaudiocpp0`.
+Note that on Ubuntu you might need to install the following packages beforehand: :code:`apt-get install python3-venv libasound-dev portaudio19-dev libportaudio2 libportaudiocpp0 python3-pyqtgraph`.
 
 Usage
 -----

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,12 @@
 cycler==0.10.0
 kiwisolver==1.1.0
 matplotlib==3.1.1
-numpy==1.17.2
-scipy
-pkg-resources==0.0.0
+numpy==1.17.3
 PyAudio==0.2.11
 pyparsing==2.4.2
 PyQt5==5.13.1
 PyQt5-sip==12.7.0
 pyqtgraph==0.10.0
 python-dateutil==2.8.0
+scipy==1.3.1
 six==1.12.0


### PR DESCRIPTION
It seems that some libraries were missing to make the second entrypoint work on Ubuntu. I am unsure about the exact package but I installed `python3-pyqtgraph` with `apt` and it pulled a few other things needed. Now everything works!